### PR TITLE
Add biometric storage helper and availability checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 1.1.0 [23.02.2025]
+
+- rememberBiometrocAuthStorage - simple method to get BiometrocAuthStorage
+- BiometricAuthHelper.isAvailable - check if biometric authorization is available on the device
+
+## 1.0.0 [03.02.2025]
+
+- BiometricAuthHelper class which implements biometric athorization
+- BiometricAuthStorage class which implements secret data storage

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ fun AuthPage() {
 }
 ```
 
+### Remember Encrypted Storage
+
+```kotlin
+val biometricAuthStorage = rememberBiometricAuthStorage {
+    println("Auth storage $it")
+    val accessToken = it.getValue("token")
+    // accessToken is a saved value
+
+    it.setValue("token", accessToken)
+    // Save accessToken to the encrypted storage
+}
+```
+
 ## API Documentation
 
 ### rememberBiometricAuthHelper
@@ -112,6 +125,18 @@ fun AuthPage() {
 - `subTitle: String`: The title which displays in the authentication dialog presented to the user. (Visible on Android only)
 - `cancelText: String`: Text for the Cancel button on the authentication dialog
 - `server: String`: The server string used by **BiometricAuthStorage** for storing secret values
+
+### rememberBiometricAuthHelper
+
+**rememberBiometricAuthStorage** is a composable function that provides an instance of the **BiometricAuthStorage**. This helper is used to access the encrypted key-value storage in a Kotlin Multiplatform project.
+
+#### Parameters
+
+- `title: String`: The title which displays in the authentication dialog presented to the user.
+- `subTitle: String`: The title which displays in the authentication dialog presented to the user. (Visible on Android only)
+- `cancelText: String`: Text for the Cancel button on the authentication dialog
+- `server: String`: The server string used by **BiometricAuthStorage** for storing secret values
+- `onFailure: (String) -> Unit`: A callback invoked when authentication fails, providing an error message.
 
 ### BiometricAuthHelper
 

--- a/biometricauthetificator/build.gradle.kts
+++ b/biometricauthetificator/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.github.zaval"
-version = "1.0.0"
+version = "1.1.0"
 
 kotlin {
 //    jvm()

--- a/biometricauthetificator/src/androidMain/kotlin/com/github/zaval/biometricauthentificator/BiometricAuthHelper.android.kt
+++ b/biometricauthetificator/src/androidMain/kotlin/com/github/zaval/biometricauthentificator/BiometricAuthHelper.android.kt
@@ -27,15 +27,16 @@ actual class BiometricAuthHelper(
     val context: Context
 ) {
 
+    private val biometricEncryptedPreferences = BiometricEncryptedPreferences(
+        title,
+        subTitle,
+        cancelText,
+        server,
+        context
+    )
+
     actual fun authenticate(onFailure: (String) -> Unit, onSuccess: (BiometricAuthStorage) -> Unit) {
 
-        val biometricEncryptedPreferences = BiometricEncryptedPreferences(
-            title,
-            subTitle,
-            cancelText,
-            server,
-            context
-        )
         biometricEncryptedPreferences.setupBiometricAccess(
             onFailure = onFailure,
             onSuccess = {sharedPreferences ->
@@ -43,6 +44,10 @@ actual class BiometricAuthHelper(
             }
         )
 
+    }
+
+    actual fun isAvailable(): Boolean {
+        return biometricEncryptedPreferences.isBiometricAvailable()
     }
 
 }

--- a/biometricauthetificator/src/androidMain/kotlin/com/github/zaval/biometricauthentificator/BiometricEncryptedPreferences.kt
+++ b/biometricauthetificator/src/androidMain/kotlin/com/github/zaval/biometricauthentificator/BiometricEncryptedPreferences.kt
@@ -93,7 +93,7 @@ class BiometricEncryptedPreferences(
         )
     }
 
-    private fun isBiometricAvailable(): Boolean {
+    fun isBiometricAvailable(): Boolean {
         val biometricManager = BiometricManager.from(context)
         return when (biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG)) {
             BiometricManager.BIOMETRIC_SUCCESS -> true


### PR DESCRIPTION
This update introduces `rememberBiometricAuthStorage`, a composable function to manage encrypted biometric storage. It also adds an `isAvailable` method to check biometric support on both Android and iOS platforms. Version incremented to 1.1.0, and changelog updated to reflect these changes.